### PR TITLE
Feature: Export serde_json::Value as unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,12 @@ include = [
     "Cargo.toml",
 ]
 
+[features]
+json_value = ["serde_json"]
+
 [dependencies]
 typescript-type-def-derive = { version = "=0.3.1", path = "./derive" }
+serde_json = { version = "1.0.64", optional = true }
 
 [dev-dependencies]
 difference = "2.0.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -235,6 +235,6 @@ where
 }
 
 #[cfg(feature = "json_value")]
-impl_native!(serde_json::Value, "any");
+impl_native!(serde_json::Value, "unknown");
 #[cfg(feature = "json_value")]
 impl_map!(serde_json::Map);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -238,3 +238,5 @@ where
 impl_native!(serde_json::Value, "unknown");
 #[cfg(feature = "json_value")]
 impl_map!(serde_json::Map);
+#[cfg(feature = "json_value")]
+impl_native!(serde_json::Number, "number");

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -233,3 +233,8 @@ where
         r#ref: TypeExpr::Ref(&T::INFO),
     });
 }
+
+#[cfg(feature = "json_value")]
+impl_native!(serde_json::Value, "any");
+#[cfg(feature = "json_value")]
+impl_map!(serde_json::Map);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -615,7 +615,7 @@ mod json_value {
             test_emit::<Test>(),
             r#"export default types;
 export namespace types{
-export type Test={"a":string;"b":any;};
+export type Test={"a":string;"b":unknown;};
 }
 "#
         );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -609,13 +609,14 @@ mod json_value {
         struct Test {
             a: String,
             b: serde_json::Value,
+            c: serde_json::Number,
         }
 
         assert_eq_str!(
             test_emit::<Test>(),
             r#"export default types;
 export namespace types{
-export type Test={"a":string;"b":unknown;};
+export type Test={"a":string;"b":unknown;"c":number;};
 }
 "#
         );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -597,3 +597,27 @@ export type Test=(types.Test3&{"a":string;"b":types.ExternalStringWrapper;"c":st
         );
     }
 }
+
+#[cfg(feature = "json_value")]
+mod json_value {
+    use super::test_emit;
+    use serde::Serialize;
+    use typescript_type_def::TypeDef;
+    #[test]
+    fn json_value() {
+        #[derive(Serialize, TypeDef)]
+        struct Test {
+            a: String,
+            b: serde_json::Value,
+        }
+
+        assert_eq_str!(
+            test_emit::<Test>(),
+            r#"export default types;
+export namespace types{
+export type Test={"a":string;"b":any;};
+}
+"#
+        );
+    }
+}


### PR DESCRIPTION
Hi, thanks for this project!

This PR add a feature `json_value` which, if enabled, exports the `serde_json::Value` type as `unknown` in the generated typescript export.

My usecase is that I have structs that contain member fields with arbitrary JSON.

*Sorry for the unrelated rustfmt changes, I forgot to disable my fmt-on-save.*