### PR TITLE
Add public method to expose a type in expression form

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -131,6 +131,20 @@ pub trait TypeDef: 'static {
     const INFO: TypeInfo;
 }
 
+impl TypeInfo {
+    /// Emit the type name with generics as an expression.
+    pub fn emit_expr<W: io::Write>(
+        &'static self,
+        mut writer: W,
+        options: DefinitionFileOptions<'_>,
+    ) -> io::Result<()> {
+        let expr = TypeExpr::Ref(self);
+        let mut ctx = EmitCtx::new(&mut writer, options);
+        expr.emit(&mut ctx)?;
+        Ok(())
+    }
+}
+
 pub(crate) struct EmitCtx<'ctx> {
     w: &'ctx mut dyn io::Write,
     options: DefinitionFileOptions<'ctx>,

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -198,7 +198,7 @@ pub struct Stats {
 }
 
 impl<'ctx> EmitCtx<'ctx> {
-    fn new(
+    pub(crate) fn new(
         w: &'ctx mut dyn io::Write,
         options: DefinitionFileOptions<'ctx>,
     ) -> Self {

--- a/src/type_expr.rs
+++ b/src/type_expr.rs
@@ -1,6 +1,12 @@
 //! This module defines structs used to create static descriptions of TypeScript
 //! type definitions.
 
+use crate::{
+    emit::{Emit, EmitCtx},
+    DefinitionFileOptions,
+};
+use std::io;
+
 /// A description of the type information required to produce a TypeScript type
 /// definition.
 #[derive(Debug, Clone, Copy)]
@@ -11,6 +17,20 @@ pub enum TypeInfo {
     /// This info describes a "defined" TypeScript type which does require a
     /// type definition.
     Defined(DefinedTypeInfo),
+}
+
+impl TypeInfo {
+    /// Emit the type name with generics as an expression.
+    pub fn emit_expr<'ctx>(
+        &'static self,
+        w: &'ctx mut dyn io::Write,
+        options: &'ctx DefinitionFileOptions<'ctx>,
+    ) -> io::Result<()> {
+        let expr = TypeExpr::Ref(self);
+        let mut ctx = EmitCtx::new(w, options.clone());
+        expr.emit(&mut ctx)?;
+        Ok(())
+    }
 }
 
 /// Type information describing a "native" TypeScript type.

--- a/src/type_expr.rs
+++ b/src/type_expr.rs
@@ -1,12 +1,6 @@
 //! This module defines structs used to create static descriptions of TypeScript
 //! type definitions.
 
-use crate::{
-    emit::{Emit, EmitCtx},
-    DefinitionFileOptions,
-};
-use std::io;
-
 /// A description of the type information required to produce a TypeScript type
 /// definition.
 #[derive(Debug, Clone, Copy)]
@@ -17,20 +11,6 @@ pub enum TypeInfo {
     /// This info describes a "defined" TypeScript type which does require a
     /// type definition.
     Defined(DefinedTypeInfo),
-}
-
-impl TypeInfo {
-    /// Emit the type name with generics as an expression.
-    pub fn emit_expr<'ctx>(
-        &'static self,
-        w: &'ctx mut dyn io::Write,
-        options: &'ctx DefinitionFileOptions<'ctx>,
-    ) -> io::Result<()> {
-        let expr = TypeExpr::Ref(self);
-        let mut ctx = EmitCtx::new(w, options.clone());
-        expr.emit(&mut ctx)?;
-        Ok(())
-    }
 }
 
 /// Type information describing a "native" TypeScript type.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -596,4 +596,27 @@ export type Test=(types.Test3&{"a":string;"b":types.ExternalStringWrapper;"c":st
 "#
         );
     }
+
+    #[test]
+    fn emit_expr() {
+        #[derive(Serialize, TypeDef)]
+        struct Message<T> {
+            op: String,
+            payload: T,
+        }
+
+        type StringMessage = Message<String>;
+        type BytesMessage = Message<Vec<u8>>;
+
+        let options = DefinitionFileOptions::default();
+        let mut s = vec![];
+        StringMessage::INFO.emit_expr(&mut s, options).unwrap();
+        assert_eq!("types.Message<string>", std::str::from_utf8(&s).unwrap());
+        let mut s = vec![];
+        BytesMessage::INFO.emit_expr(&mut s, options).unwrap();
+        assert_eq!(
+            "types.Message<(types.U8)[]>",
+            std::str::from_utf8(&s).unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Hi, this PR proposes a public method `emit_expr` on the `TypeInfo` struct. The method serializes the type as a TypeScript expression (e.g. `SomeStruct<U32>` or `string`). I'm using this to create TypeScript method stubs for an autogenerated RPC client.

This PR still misses tests, which I didn't write yet.