### PR TITLE
Allow generation of definition file for runtime-created list of types

### DIFF
--- a/src/iter_def_deps.rs
+++ b/src/iter_def_deps.rs
@@ -22,9 +22,9 @@ pub struct IterDefDeps {
 
 impl IterDefDeps {
     /// Creates a new iterator of the dependencies of the given type info.
-    pub fn new(root: &'static TypeInfo) -> Self {
+    pub fn new(roots: &[&'static TypeInfo]) -> Self {
         Self {
-            stack: vec![TypeExpr::Ref(root)],
+            stack: roots.iter().map(|x| TypeExpr::Ref(x)).collect(),
             visited: HashSet::new(),
             emitted: HashSet::new(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,8 @@ mod iter_def_deps;
 pub mod type_expr;
 
 pub use crate::emit::{
-    write_definition_file, DefinitionFileOptions, Stats, TypeDef,
+    write_definition_file, write_definition_file_many, DefinitionFileOptions,
+    Stats, TypeDef,
 };
 
 /// A derive proc-macro for the [`TypeDef`] trait.


### PR DESCRIPTION
Currently `write_definition_file` requires full list of types at compile time, my use-case however does not give me the possibility to know all the required types statically. Would you be interested in including this PR?
