### PR TITLE
Add impl for &'static str

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -26,6 +26,8 @@ impl_native!(Blob, "Blob");
 impl_native!(bool, "boolean");
 impl_native!(String, "string");
 impl_native!(str, "string");
+impl_native!(&'static str, "string");
+
 #[cfg(feature = "json_value")]
 impl_native!(serde_json::Number, "number");
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -67,6 +67,26 @@ export type Test=(Record<(types.Usize|null),(string)[]>)[];
     assert_eq!(stats.type_definitions, 2);
 }
 
+#[test]
+fn static_str() {
+    let mut buf = Vec::new();
+    #[derive(Serialize, TypeDef)]
+    struct Test {
+        a: Vec<&'static str>,
+    }
+    write_definition_file::<_, Test>(&mut buf, TEST_OPTIONS).unwrap();
+    let emitted = String::from_utf8(buf).unwrap();
+    eprintln!("EM {}", emitted);
+    assert_eq_str!(
+        emitted,
+        r#"export default types;
+export namespace types{
+export type Test={"a":(string)[];};
+}
+"#
+    );
+}
+
 mod derive {
     #![allow(dead_code)]
 


### PR DESCRIPTION
Hi,
the `str` impl does not work for `'static &str`. This PR adds an impl for `'static &str` and a test case that fails without the addition.

Thanks,
Franz