### PR TITLE
Add support for `#[serde(untagged)]` attributes on individual enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vNEXT
+
+* Add support for `#[serde(untagged)]` on variants ([#36](https://github.com/dbeckwith/rust-typescript-type-def/pull/36)).
+
 ## v0.5.13
 
 * Add support for `#[serde(rename_all_fields)]` ([#35](https://github.com/dbeckwith/rust-typescript-type-def/issues/35)).

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -239,6 +239,8 @@ struct TypeDefVariant {
     #[darling(default)]
     rename: Option<SpannedValue<String>>,
     #[darling(default)]
+    untagged: SpannedValue<Flag>,
+    #[darling(default)]
     #[allow(dead_code)]
     alias: Ignored,
     #[darling(default)]
@@ -506,7 +508,7 @@ fn variants_to_type_expr(
     tag: &Option<SpannedValue<String>>,
     content: &Option<SpannedValue<String>>,
     untagged: &SpannedValue<Flag>,
-    variant_rename_all: &Option<SpannedValue<String>>,
+    rename_all: &Option<SpannedValue<String>>,
     fields_rename_all: &Option<SpannedValue<String>>,
     generics: &Generics,
 ) -> Expr {
@@ -518,17 +520,18 @@ fn variants_to_type_expr(
                  fields: ast::Fields { style, fields, .. },
                  rename_all: field_rename_all,
                  rename: variant_rename,
+                 untagged: variant_untagged,
                  ..
              }| {
                 let variant_name = serde_rename_ident(
                     variant_name,
                     variant_rename,
-                    variant_rename_all.as_ref(),
+                    rename_all.as_ref(),
                     false,
                 );
                 let field_rename_all =
                     field_rename_all.as_ref().or(fields_rename_all.as_ref());
-                match (tag, content, ***untagged) {
+                match (tag, content, ***untagged || ***variant_untagged) {
                     (None, None, false) => match style {
                         ast::Style::Unit => type_expr_string(
                             &variant_name.value(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -469,6 +469,34 @@ export namespace types {
         }
 
         #[test]
+        fn untagged_variant() {
+            #[derive(Serialize, TypeDef)]
+            enum Test {
+                A,
+                B,
+                C,
+                #[serde(untagged)]
+                Other(String),
+            }
+
+            assert_eq_str!(serde_json::to_string(&Test::A).unwrap(), r#""A""#);
+            assert_eq_str!(serde_json::to_string(&Test::B).unwrap(), r#""B""#);
+            assert_eq_str!(serde_json::to_string(&Test::C).unwrap(), r#""C""#);
+            assert_eq_str!(
+                serde_json::to_string(&Test::Other("D".to_string())).unwrap(),
+                r#""D""#
+            );
+            assert_eq_str!(
+                test_emit::<Test>(),
+                r#"export default types;
+export namespace types {
+    export type Test = ("A" | "B" | "C" | string);
+}
+"#
+            );
+        }
+
+        #[test]
         fn none() {
             #[derive(Serialize, TypeDef)]
             enum Test {


### PR DESCRIPTION
By lacking support for `#[serde(untagged)]` attributes on individual enum variants the crate fails to support a common pattern for modeling string-based enums:

```typescript
type Kind = "foo" | "bar" | "baz" | "blee" | string;
```

```rust
#[derive(Serialize, TypeDef)]
#[serde(rename_all = "kebab-case")]
pub enum Kind {
    Foo,
    Bar,
    Baz,
    Blee,
    #[serde(untagged)]
    Unknown(String),
}
```

Deserializing unknown "kind" values as `Kind::Unknown(…)` makes `Kind` future-proof, which is particularly import in scenarios where one does not control the source providing the serialized representations of `Kind`, but also has a requirement to never fail on unexpected values.

In the particular scenario above the following would work just fine, as is:

```rust
#[derive(Serialize, TypeDef)]
#[serde(untagged, rename_all = "kebab-case")]
pub enum Kind {
    Foo,
    Bar,
    Baz,
    Blee,
    Unknown(String),
}
```

… but there are other scenarios where an enum-level `#[serde(untagged)]` is undesirable, such as if individual "known" variants had additional fields.